### PR TITLE
Return True when creating or setting state for a Unit

### DIFF
--- a/fleet/v1/client.py
+++ b/fleet/v1/client.py
@@ -488,7 +488,7 @@ class Client(object):
             unit (Unit): The unit to submit to fleet
 
         Returns:
-            Unit: The unit that was created
+            True: The request was successful
 
         Raises:
             fleet.v1.errors.APIError: Fleet returned a response code >= 400
@@ -500,7 +500,7 @@ class Client(object):
             'options': unit.options
         })
 
-        return self.get_unit(name)
+        return True
 
     def set_unit_desired_state(self, unit, desired_state):
         """Update the desired state of a unit running in the cluster
@@ -511,7 +511,7 @@ class Client(object):
             desired_state: State the user wishes the Unit to be in
                           ("inactive", "loaded", or "launched")
         Returns:
-            Unit: The unit that was updated
+            True: The request was successful
 
         Raises:
             fleet.v1.errors.APIError: Fleet returned a response code >= 400
@@ -535,7 +535,7 @@ class Client(object):
             'desiredState': desired_state
         })
 
-        return self.get_unit(unit)
+        return True
 
     def destroy_unit(self, unit):
         """Delete a unit from the cluster

--- a/fleet/v1/tests/test_client.py
+++ b/fleet/v1/tests/test_client.py
@@ -311,8 +311,7 @@ class TestFleetClient(unittest.TestCase):
             Unit(from_file=os.path.join(self._BASE_DIR, 'fixtures/test.service'))
         )
 
-        assert unit
-        assert unit.name == 'test.service'
+        self.assertTrue(unit)
 
     def test_set_unit_desired_state_bad(self):
         """ValueError is raised when an invalid state is passed"""
@@ -334,8 +333,7 @@ class TestFleetClient(unittest.TestCase):
 
         unit = self.client.set_unit_desired_state('test.service', 'inactive')
 
-        assert unit
-        assert unit.desiredState == 'inactive'
+        self.assertTrue(unit)
 
     def test_set_unit_obj_desired_state_good(self):
         """Unit Desired State can be updated by object"""
@@ -352,8 +350,7 @@ class TestFleetClient(unittest.TestCase):
 
         unit = self.client.set_unit_desired_state(unit, 'inactive')
 
-        assert unit
-        assert unit.desiredState == 'inactive'
+        self.assertTrue(unit)
 
     def test_destroy_unit_name(self):
         """Destroy a unit by name"""

--- a/fleet/v1/tests/test_unit.py
+++ b/fleet/v1/tests/test_unit.py
@@ -318,6 +318,6 @@ class TestUnit(unittest.TestCase):
 
         assert unit.desiredState == 'launched'
 
-        assert unit.set_desired_state('inactive') == 'inactive'
+        self.assertTrue(unit.set_desired_state('inactive'))
 
         assert unit.desiredState == 'inactive'


### PR DESCRIPTION
This matches how the fleet API works, see https://coreos.com/fleet/docs/latest/api-v1.html#create-a-unit
@cnelson we've been using this for a couple of days and we no longer see failures when creating units

Fixes #5 

Note that because of the Google API client library it's not possible to explicitly validate the response code.
Also, do you still want to raise a `fleet.v1.errors.APIError`? In that case I'll have to add some code that catches whatever error the Google API client library throws and return a `fleet.v1.errors.APIError`